### PR TITLE
Minor fix to comparison table

### DIFF
--- a/webpacker_guide.md
+++ b/webpacker_guide.md
@@ -36,7 +36,7 @@ If you are familiar with Sprockets, the following guide might give you some idea
 |Attach CSS        |stylesheet_link_tag|stylesheet_pack_tag|
 |Link to an image  |image_url          |image_pack_tag     |
 |Link to an asset  |asset_url          |asset_pack_tag     |
-|Require a script  |//= require        |require or include |
+|Require a script  |//= require        |import or require  |
 
 ## Installing Webpacker
 


### PR DESCRIPTION
I think `include` should be `import` and would like to emphasis `import` over `require` in an effort to promote ES module syntax.